### PR TITLE
Add subdivision LOD distance for grass

### DIFF
--- a/Assets/InfiniteGrass/Materials/Grass Blade.mat
+++ b/Assets/InfiniteGrass/Materials/Grass Blade.mat
@@ -57,6 +57,7 @@ Material:
     - _GrassWidth: 0.25
     - _GrassWidthRandomness: 0.25
     - _MaxSubdivision: 5
+    - _SubdivisionDistance: 100
     - _QueueControl: 0
     - _QueueOffset: 0
     - _RandomNormal: 0.229

--- a/Assets/InfiniteGrass/Scripts/InfiniteGrassRenderer.cs
+++ b/Assets/InfiniteGrass/Scripts/InfiniteGrassRenderer.cs
@@ -17,6 +17,7 @@ public class InfiniteGrassRenderer : MonoBehaviour
     [Header("Grass Properties")]
     public float spacing = 0.5f;//Spacing between blades, Please don't make it too low
     public float drawDistance = 300;
+    public float subdivisionDistance = 100;//Distance where grass mesh subdivisions fade out
     public float fullDensityDistance = 30;//Distance around the camera kept at full density
     [Tooltip("Controls how quickly grass fades with distance (higher is steeper)")]
     public float densityFalloffExponent = 4f;
@@ -71,6 +72,7 @@ public class InfiniteGrassRenderer : MonoBehaviour
         //Material Setup ------------------------------------------------------------
         grassMaterial.SetVector("_CenterPos", centerPos);
         grassMaterial.SetFloat("_DrawDistance", drawDistance);
+        grassMaterial.SetFloat("_SubdivisionDistance", subdivisionDistance);
         grassMaterial.SetFloat("_TextureUpdateThreshold", textureUpdateThreshold);
         grassMaterial.SetFloat("_MaxSubdivision", grassMeshSubdivision);
 

--- a/Assets/InfiniteGrass/Shaders/GrassBladeShader.shader
+++ b/Assets/InfiniteGrass/Shaders/GrassBladeShader.shader
@@ -27,6 +27,7 @@
         [Header(Lighting)][Space]
         _RandomNormal("Random Normal", Range(0, 1)) = 0.1
         _MaxSubdivision("Max Subdivision", Float) = 5
+        _SubdivisionDistance("Subdivision Distance", Float) = 100
     }
 
     SubShader
@@ -90,6 +91,7 @@
                 float _DrawDistance;
                 float _TextureUpdateThreshold;
                 float _MaxSubdivision;
+                float _SubdivisionDistance;
 
                 StructuredBuffer<float4> _GrassPositions;
 
@@ -172,7 +174,7 @@
                 float2 uv = (pivot.xz - _CenterPos) / (_DrawDistance + _TextureUpdateThreshold);
                 uv = uv * 0.5 + 0.5;
 
-                float lodSubdiv = floor(_MaxSubdivision * saturate(1 - distanceFromCamera / _DrawDistance));
+                float lodSubdiv = floor(_MaxSubdivision * saturate(1 - distanceFromCamera / _SubdivisionDistance));
                 float step = 1.0 / (lodSubdiv + 1);
                 float quantizedY = round(IN.positionOS.y / step) * step;
 

--- a/Assets/Sample Scene/SampleScene.unity
+++ b/Assets/Sample Scene/SampleScene.unity
@@ -15323,6 +15323,7 @@ MonoBehaviour:
   grassMaterial: {fileID: 2100000, guid: 851879c6d723afb4a8aaa2242cee777c, type: 2}
   spacing: 0.1
   drawDistance: 250
+  subdivisionDistance: 100
   fullDensityDistance: 0.5
   densityFalloffExponent: 4
   grassMeshSubdivision: 5


### PR DESCRIPTION
## Summary
- allow grass subdivision to fade at a custom distance
- expose `subdivisionDistance` property on `InfiniteGrassRenderer`
- send new distance to the material and use it in the shader
- update material and scene defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68494c3250948330836a64f07577adcc