### PR TITLE
Fix scene view camera jitter

### DIFF
--- a/Assets/InfiniteGrass/Scripts/GrassDataRendererFeature.cs
+++ b/Assets/InfiniteGrass/Scripts/GrassDataRendererFeature.cs
@@ -306,7 +306,13 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
                 _computeShader.SetFloat (DrawDistance,          d.DrawDistance);
                 _computeShader.SetFloat (TextureUpdateThreshold,d.TextureThreshold);
                 _computeShader.SetFloat (Spacing,               d.Spacing);
-                
+
+                // Update material globals so the grass draw call for this
+                // camera uses the matching parameters and textures.
+                cmd.SetGlobalVector(CenterPos, d.CenterPos);
+                cmd.SetGlobalFloat(DrawDistance, d.DrawDistance);
+                cmd.SetGlobalFloat(TextureUpdateThreshold, d.TextureThreshold);
+
                 Vector2Int gridSize  = new(
                     Mathf.CeilToInt(d.Bounds.size.x / d.Spacing),
                     Mathf.CeilToInt(d.Bounds.size.z / d.Spacing));

--- a/Assets/InfiniteGrass/Scripts/GrassDataRendererFeature.cs
+++ b/Assets/InfiniteGrass/Scripts/GrassDataRendererFeature.cs
@@ -108,6 +108,8 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
             var slopeTex = rg.ImportTexture(_slopeRT);
 
             var camera = _renderingData.cameraData.camera;
+            if (InfiniteGrassRenderer.instance)
+                InfiniteGrassRenderer.instance.currentRenderCamera = camera;
             var spacing = InfiniteGrassRenderer.instance.spacing;
             var fullDensityDist = InfiniteGrassRenderer.instance.fullDensityDistance;
             var drawDistance = InfiniteGrassRenderer.instance.drawDistance;


### PR DESCRIPTION
## Summary
- track the camera used in render passes
- use that camera when drawing grass to avoid scene view jitter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c8d3256ec833098ae059811803ac5