### PR TITLE
Improve URP render graph usage

### DIFF
--- a/Assets/InfiniteGrass/Scripts/GrassDataRendererFeature.cs
+++ b/Assets/InfiniteGrass/Scripts/GrassDataRendererFeature.cs
@@ -159,7 +159,7 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
             {
                 var cmd = ctx.cmd;
                 cmd.SetViewProjectionMatrices(data.View, data.Projection);
-                cmd.ClearRenderTarget(true, true, Color.black);
+                cmd.ClearRenderTarget(false, false, Color.clear);
                 cmd.DrawRendererList(data.RendererList);
             });
         }
@@ -183,7 +183,7 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
             {
                 var cmd = ctx.cmd;
                 cmd.SetViewProjectionMatrices(data.View, data.Projection);
-                cmd.ClearRenderTarget(true, true, Color.clear);
+                cmd.ClearRenderTarget(false, false, Color.clear);
                 cmd.DrawRendererList(data.RendererList);
             });
         }
@@ -207,7 +207,7 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
             {
                 var cmd = ctx.cmd;
                 cmd.SetViewProjectionMatrices(data.View, data.Projection);
-                cmd.ClearRenderTarget(true, true, Color.clear);
+                cmd.ClearRenderTarget(false, false, Color.clear);
                 cmd.DrawRendererList(data.RendererList);
             });
         }
@@ -231,7 +231,7 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
             {
                 var cmd = ctx.cmd;
                 cmd.SetViewProjectionMatrices(data.View, data.Projection);
-                cmd.ClearRenderTarget(true, true, Color.clear);
+                cmd.ClearRenderTarget(false, false, Color.clear);
                 cmd.DrawRendererList(data.RendererList);
             });
         }
@@ -262,6 +262,7 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
             var posHandle = rg.ImportBuffer(_grassPositionsBuffer);
 
             using var builder = rg.AddComputePass<ComputePassData>("Grass Compute", out var pass);
+            builder.EnableAsyncCompute(true);
             
             pass.Height           = height;
             pass.Mask             = mask;
@@ -338,23 +339,40 @@ public class GrassDataRendererFeature : ScriptableRendererFeature
 
         private void AllocateRtHandles(int size)
         {
-            var heightDesc = new RenderTextureDescriptor(size, size) { graphicsFormat = GraphicsFormat.R32G32_SFloat };
+            var heightDesc = new RenderTextureDescriptor(size, size)
+            {
+                graphicsFormat = GraphicsFormat.R16G16_SFloat,
+                memoryless     = RenderTextureMemoryless.Color
+            };
             RenderingUtils.ReAllocateHandleIfNeeded(ref _heightRT, heightDesc, FilterMode.Bilinear);
 
             var depthDesc = new RenderTextureDescriptor(size, size)
             {
-                graphicsFormat = GraphicsFormat.None,
-                depthStencilFormat = GraphicsFormat.D32_SFloat
+                graphicsFormat     = GraphicsFormat.None,
+                depthStencilFormat = GraphicsFormat.D32_SFloat,
+                memoryless         = RenderTextureMemoryless.Depth
             };
             RenderingUtils.ReAllocateHandleIfNeeded(ref _heightDepthRT, depthDesc, FilterMode.Bilinear);
 
-            var maskDesc = new RenderTextureDescriptor(size, size) { graphicsFormat = GraphicsFormat.R32_SFloat };
+            var maskDesc = new RenderTextureDescriptor(size, size)
+            {
+                graphicsFormat = GraphicsFormat.R16_SFloat,
+                memoryless     = RenderTextureMemoryless.Color
+            };
             RenderingUtils.ReAllocateHandleIfNeeded(ref _maskRT, maskDesc, FilterMode.Bilinear);
 
-            var colorDesc = new RenderTextureDescriptor(size, size) { graphicsFormat = GraphicsFormat.R32G32B32A32_SFloat };
+            var colorDesc = new RenderTextureDescriptor(size, size)
+            {
+                graphicsFormat = GraphicsFormat.R16G16B16A16_SFloat,
+                memoryless     = RenderTextureMemoryless.Color
+            };
             RenderingUtils.ReAllocateHandleIfNeeded(ref _colorRT, colorDesc, FilterMode.Bilinear);
 
-            var slopeDesc = new RenderTextureDescriptor(size, size) { graphicsFormat = GraphicsFormat.R32G32B32A32_SFloat };
+            var slopeDesc = new RenderTextureDescriptor(size, size)
+            {
+                graphicsFormat = GraphicsFormat.R16G16B16A16_SFloat,
+                memoryless     = RenderTextureMemoryless.Color
+            };
             RenderingUtils.ReAllocateHandleIfNeeded(ref _slopeRT, slopeDesc, FilterMode.Bilinear);
         }
 


### PR DESCRIPTION
## Summary
- optimize RT creation with lower precision, memoryless descriptors
- run the grass compute pass asynchronously
- avoid clearing intermediate attachments

## Testing
- `npm test` *(fails: could not read package.json)*
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_684c8db990188330b989eb17bc75f802