### PR TITLE
Fade grass AO with distance

### DIFF
--- a/Runtime/Scripts/InfiniteGrassRenderer.cs
+++ b/Runtime/Scripts/InfiniteGrassRenderer.cs
@@ -14,6 +14,8 @@ public class InfiniteGrassRenderer : MonoBehaviour
     private static readonly int SubdivisionBumpWidth = Shader.PropertyToID("_SubdivisionBumpWidth");
     private static readonly int TextureUpdateThreshold = Shader.PropertyToID("_TextureUpdateThreshold");
     private static readonly int MaxSubdivision = Shader.PropertyToID("_MaxSubdivision");
+    private static readonly int FullDensityDistanceID = Shader.PropertyToID("_FullDensityDistance");
+    private static readonly int DensityFalloffExponentID = Shader.PropertyToID("_DensityFalloffExponent");
 
     [Header("Internal")]
     public Material grassMaterial;
@@ -80,6 +82,8 @@ public class InfiniteGrassRenderer : MonoBehaviour
         grassMaterial.SetFloat(SubdivisionBumpWidth, subdivisionBumpWidth);
         grassMaterial.SetFloat(TextureUpdateThreshold, textureUpdateThreshold);
         grassMaterial.SetFloat(MaxSubdivision, grassMeshSubdivision);
+        grassMaterial.SetFloat(FullDensityDistanceID, fullDensityDistance);
+        grassMaterial.SetFloat(DensityFalloffExponentID, densityFalloffExponent);
     }
 
 #if DEBUG

--- a/Runtime/Shaders/GrassBladeShader.shader
+++ b/Runtime/Shaders/GrassBladeShader.shader
@@ -178,9 +178,10 @@
                 float2 uv = (pivot.xz - _CenterPos) / (_DrawDistance + _TextureUpdateThreshold);
                 uv = uv * 0.5 + 0.5;
 
-                float aoFalloff = saturate(1.0 - distanceFromCamera / _DrawDistance);
-                aoFalloff = pow(aoFalloff, _DensityFalloffExponent);
-                aoFalloff = saturate(aoFalloff * _FullDensityDistance);
+                // AO strength uses the same distance falloff as blade density
+                float aoDistanceFactor = saturate(1.0 - distanceFromCamera / _DrawDistance);
+                aoDistanceFactor = pow(aoDistanceFactor, _DensityFalloffExponent);
+                aoDistanceFactor = saturate(aoDistanceFactor * _FullDensityDistance);
 
                 float lodSubdiv = floor(_MaxSubdivision * saturate(1 - distanceFromCamera / _SubdivisionDistance));
                 float step = 1.0 / (lodSubdiv + 1);
@@ -232,8 +233,8 @@
                 //posWS -> posCS
                 OUT.positionCS = TransformWorldToHClip(positionWS);
                 
-                half3 albedo = lerp(_AOColor, _Color, quantizedY);
-                albedo = lerp(_Color, albedo, aoFalloff);
+                half3 baseAlbedo = lerp(_AOColor, _Color, quantizedY);
+                half3 albedo = lerp(_Color, baseAlbedo, aoDistanceFactor);
 
                 float4 color = tex2Dlod(_GrassColorRT, float4(uv, 0, 0));
                 albedo = lerp(albedo, color.rgb, color.a);

--- a/Runtime/Shaders/GrassBladeShader.shader
+++ b/Runtime/Shaders/GrassBladeShader.shader
@@ -28,6 +28,8 @@
         _SubdivisionDistance("Subdivision Distance", Float) = 100
         _SubdivisionHeightBoost("Subdivision Height Boost", Float) = 0
         _SubdivisionBumpWidth("Subdivision Bump Width", Float) = 20
+        _FullDensityDistance("Full Density Distance", Float) = 30
+        _DensityFalloffExponent("Density Falloff Exponent", Float) = 4
     }
 
     SubShader
@@ -92,6 +94,9 @@
                 float _SubdivisionDistance;
                 float _SubdivisionHeightBoost;
                 float _SubdivisionBumpWidth;
+
+                float _FullDensityDistance;
+                float _DensityFalloffExponent;
 
                 StructuredBuffer<float4> _GrassPositions;
 
@@ -173,6 +178,10 @@
                 float2 uv = (pivot.xz - _CenterPos) / (_DrawDistance + _TextureUpdateThreshold);
                 uv = uv * 0.5 + 0.5;
 
+                float aoFalloff = saturate(1.0 - distanceFromCamera / _DrawDistance);
+                aoFalloff = pow(aoFalloff, _DensityFalloffExponent);
+                aoFalloff = saturate(aoFalloff * _FullDensityDistance);
+
                 float lodSubdiv = floor(_MaxSubdivision * saturate(1 - distanceFromCamera / _SubdivisionDistance));
                 float step = 1.0 / (lodSubdiv + 1);
                 float quantizedY = round(IN.positionOS.y / step) * step;
@@ -224,6 +233,7 @@
                 OUT.positionCS = TransformWorldToHClip(positionWS);
                 
                 half3 albedo = lerp(_AOColor, _Color, quantizedY);
+                albedo = lerp(_Color, albedo, aoFalloff);
 
                 float4 color = tex2Dlod(_GrassColorRT, float4(uv, 0, 0));
                 albedo = lerp(albedo, color.rgb, color.a);


### PR DESCRIPTION
## Summary
- make AO fade at long range in base blade shader
- expose distance falloff parameters on `InfiniteGrassRenderer`

## Testing
- `npm install` *(fails: No matching version for com.unity.render-pipelines.universal@17.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c1f783083309e35b988715e305b